### PR TITLE
fix: run-hooks report "Wrong type argument" error

### DIFF
--- a/text-scale+.el
+++ b/text-scale+.el
@@ -164,7 +164,7 @@ See `text-scale+-faces-list'."
 
 (defun text-scale+--run-text-scale-mode-hooks ()
   "Run all hooks from `text-scale-mode-hook'."
-  (run-hooks text-scale-mode-hook))
+  (run-hooks 'text-scale-mode-hook))
 
 ;;;###autoload
 (defun text-scale+-install ()


### PR DESCRIPTION
Emacs version:
    GNU Emacs 30.0.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.35, cairo version 1.17.6) of 2022-12-05
